### PR TITLE
define peerDependencies required for tailwind plugin

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -108,5 +108,11 @@
     "framer-motion": "~10.12.16",
     "react-aria": "~3.25.0",
     "react-stately": "~3.23.0"
+  },
+  "peerDependencies": {
+    "colorjs.io": "~0.4.5",
+    "tailwind-variants": "~0.1.13",
+    "tailwindcss": "~3.3.2",
+    "tailwindcss-themer": "~3.1.0"
   }
 }


### PR DESCRIPTION
Define peer dependencies required for Tailwind plugin so that consumers not going to get a build error.