### PR TITLE
fixes/focus-outline

### DIFF
--- a/packages/ui/src/components/accordion/components/accordion-item/accordion-item.component.tsx
+++ b/packages/ui/src/components/accordion/components/accordion-item/accordion-item.component.tsx
@@ -1,7 +1,7 @@
 import { useAccordionItem } from '@react-aria/accordion';
 import { AnimatePresence, LazyMotion, m } from 'framer-motion';
 import React, { useRef } from 'react';
-import { mergeProps, useHover, useLocale } from 'react-aria';
+import { mergeProps, useFocusRing, useHover, useLocale } from 'react-aria';
 
 import { ArrowLeftIcon, ArrowRightIcon } from '../../../icon/index.js';
 
@@ -20,11 +20,12 @@ export function AccordionItem<T = any>({
   const ref = useRef<HTMLButtonElement>(null);
   const { state, item } = props;
   const { buttonProps, regionProps } = useAccordionItem<T>(props, state, ref);
+  const { isFocusVisible, focusProps } = useFocusRing();
   const isOpen = state.expandedKeys.has(item.key);
   const isDisabled = state.disabledKeys.has(item.key);
   const { hoverProps } = useHover({ isDisabled });
   const { direction } = useLocale();
-  const styles = accordionItemStyles({ isOpen, isDisabled, className, color, look });
+  const styles = accordionItemStyles({ isOpen, isDisabled, className, color, look, isFocusVisible });
 
   return (
     <Tag className={styles.base()}>
@@ -33,7 +34,7 @@ export function AccordionItem<T = any>({
         https://www.w3.org/WAI/ARIA/apg/patterns/accordion/examples/accordion/
       */}
       <h3>
-        <button {...mergeProps(buttonProps, hoverProps)} ref={ref} className={styles.itemHeader()}>
+        <button {...mergeProps(buttonProps, hoverProps, focusProps)} ref={ref} className={styles.itemHeader()}>
           <span>{item.props.title}</span>
           {look === 'material' && <div aria-hidden="true" className={styles.indicator()} />}
           {look === 'default' &&

--- a/packages/ui/src/components/accordion/components/accordion-item/accordion-item.styles.ts
+++ b/packages/ui/src/components/accordion/components/accordion-item/accordion-item.styles.ts
@@ -4,33 +4,33 @@ export const styles = tv(
   {
     slots: {
       base: '',
-      itemHeader: 'typography-body-9 flex w-full items-center justify-between px-3 py-2 focus:focus-outline',
+      itemHeader: 'typography-body-9 flex w-full items-center justify-between px-3 py-2',
       indicator: '',
       content: 'hidden',
     },
     variants: {
       look: {
         material: {
-          itemHeader: 'bg-white transition-colors hover:bg-light',
+          itemHeader: 'hover:bg-light bg-white transition-colors',
           indicator:
-            'relative h-2 w-2 before:absolute before:left-1/2 before:top-1/2 before:block before:h-[2px] before:w-full before:-translate-x-1/2 before:-translate-y-1/2 before:bg-muted after:absolute after:left-1/2 after:top-1/2 after:block after:h-full after:w-[2px] after:-translate-x-1/2 after:-translate-y-1/2 after:bg-muted after:transition-transform',
+            'before:bg-muted after:bg-muted relative h-2 w-2 before:absolute before:left-1/2 before:top-1/2 before:block before:h-[2px] before:w-full before:-translate-x-1/2 before:-translate-y-1/2 after:absolute after:left-1/2 after:top-1/2 after:block after:h-full after:w-[2px] after:-translate-x-1/2 after:-translate-y-1/2 after:transition-transform',
         },
         default: {
-          itemHeader: 'border-t border-border bg-light',
+          itemHeader: 'border-border bg-light border-t',
           indicator: 'h-3 w-3 -rotate-90 transition-transform',
         },
       },
       color: {
         hero: {
-          itemHeader: 'border-l-[0.375rem] border-l-border transition-colors',
+          itemHeader: 'border-l-border border-l-[0.375rem] transition-colors',
         },
         primary: {
-          itemHeader: 'border-l-[0.375rem] border-l-border transition-colors',
+          itemHeader: 'border-l-border border-l-[0.375rem] transition-colors',
         },
       },
       isOpen: {
         true: {
-          content: 'block border-t border-border p-3',
+          content: 'border-border block border-t p-3',
         },
         false: {
           base: '',
@@ -39,6 +39,14 @@ export const styles = tv(
       isDisabled: {
         true: '',
         false: '',
+      },
+      isFocusVisible: {
+        true: {
+          itemHeader: 'focus-outline',
+        },
+        false: {
+          itemHeader: 'outline-none',
+        },
       },
     },
     compoundSlots: [
@@ -69,12 +77,12 @@ export const styles = tv(
       {
         slots: ['content'],
         color: 'hero',
-        className: 'border-l-[0.375rem] border-l-border',
+        className: 'border-l-border border-l-[0.375rem]',
       },
       {
         slots: ['content'],
         color: 'primary',
-        className: 'border-l-[0.375rem] border-l-border',
+        className: 'border-l-border border-l-[0.375rem]',
       },
     ],
   },

--- a/packages/ui/src/components/autocomplete/autocomplete.spec.tsx
+++ b/packages/ui/src/components/autocomplete/autocomplete.spec.tsx
@@ -24,12 +24,12 @@ describe('Autocomplete', () => {
     // TODO: use some variants for test
     expect(style.base()).toBe('relative flex flex-col');
     expect(style.clearButton()).toBe(
-      'flex cursor-default items-center justify-center text-text-50 hover:text-border-60',
+      'text-text-50 hover:text-border-60 flex cursor-default items-center justify-center',
     );
     expect(style.input()).toBe('w-full appearance-none bg-[transparent] outline-none form-control-large');
-    expect(style.label()).toBe('block text-left text-sm font-medium text-text');
+    expect(style.label()).toBe('text-text block text-left text-sm font-medium');
     expect(style.outerWrapper()).toBe(
-      'form-control relative flex w-full flex-row items-center overflow-hidden pr-2 disabled:form-control-disabled focus:focus-outline',
+      'form-control disabled:form-control-disabled relative flex w-full flex-row items-center overflow-hidden pr-2',
     );
   });
 

--- a/packages/ui/src/components/autocomplete/autocomplete.styles.ts
+++ b/packages/ui/src/components/autocomplete/autocomplete.styles.ts
@@ -4,11 +4,11 @@ export const styles = tv(
   {
     slots: {
       base: 'relative flex flex-col',
-      label: 'block text-left text-sm font-medium text-text',
+      label: 'text-text block text-left text-sm font-medium',
       outerWrapper:
-        'form-control relative flex w-full flex-row items-center overflow-hidden pr-2 disabled:form-control-disabled focus:focus-outline',
+        'form-control disabled:form-control-disabled relative flex w-full flex-row items-center overflow-hidden pr-2',
       input: 'w-full appearance-none bg-[transparent] outline-none',
-      clearButton: 'flex cursor-default items-center justify-center text-text-50 hover:text-border-60',
+      clearButton: 'text-text-50 hover:text-border-60 flex cursor-default items-center justify-center',
     },
     variants: {
       invalid: {

--- a/packages/ui/src/components/button-dropdown/button-dropdown.styles.ts
+++ b/packages/ui/src/components/button-dropdown/button-dropdown.styles.ts
@@ -3,7 +3,7 @@ import { tv } from 'tailwind-variants';
 export const styles = tv(
   {
     slots: {
-      base: 'focus:focus-outline',
+      base: '',
       panel: 'overflow-hidden',
     },
     variants: {

--- a/packages/ui/src/components/button-dropdown/components/panel/panel.component.tsx
+++ b/packages/ui/src/components/button-dropdown/components/panel/panel.component.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useRef } from 'react';
-import { DismissButton, Overlay, mergeProps, useOverlay, usePopover } from 'react-aria';
+import { DismissButton, Overlay, mergeProps, useFocusRing, useOverlay, usePopover } from 'react-aria';
 
 import { styles as panelStyles } from './panel.styles.js';
 import { type PanelProps } from './panel.types.js';
@@ -8,7 +8,8 @@ export function Panel({ className, children, state, block, id, ...props }: Panel
   const popoverRef = useRef<HTMLDivElement>(null);
   const { overlayProps } = useOverlay({ shouldCloseOnBlur: true, onClose: state.close }, popoverRef);
   const { popoverProps } = usePopover({ popoverRef, shouldFlip: false, ...props }, state);
-  const styles = panelStyles({});
+  const { isFocused, focusProps } = useFocusRing();
+  const styles = panelStyles({ isFocused });
   const width = props.triggerRef.current?.getBoundingClientRect().width;
 
   // Added this based on accessibility features seen https://gel.westpacgroup.com.au/design-system/components/button-dropdowns?b=WBC&tab=accessibility and React Aria doesn't do this
@@ -30,7 +31,7 @@ export function Panel({ className, children, state, block, id, ...props }: Panel
   return (
     <Overlay>
       <div
-        {...mergeProps(popoverProps, overlayProps)}
+        {...mergeProps(popoverProps, overlayProps, focusProps)}
         id={id}
         data-testid="panel-dialog"
         style={{ ...popoverProps.style, width: block && width ? `${width}px` : undefined }}

--- a/packages/ui/src/components/button-dropdown/components/panel/panel.styles.ts
+++ b/packages/ui/src/components/button-dropdown/components/panel/panel.styles.ts
@@ -5,9 +5,15 @@ export const styles = tv(
   {
     slots: {
       base: 'border-border mt-[0.1875rem] rounded-[3px] border bg-white p-2 shadow-[0_0.375rem_0.75rem_rgba(0,0,0,0.175)]',
-      dialog: 'focus:outline-none',
+      dialog: '',
     },
-    variants: {},
+    variants: {
+      isFocused: {
+        true: {
+          dialog: 'outline-none',
+        },
+      },
+    },
   },
   { responsiveVariants: ['xsl', 'sm', 'md', 'lg', 'xl'] },
 );

--- a/packages/ui/src/components/button/button.component.tsx
+++ b/packages/ui/src/components/button/button.component.tsx
@@ -1,7 +1,5 @@
 import React, { forwardRef, useMemo } from 'react';
-import { FocusRing } from 'react-aria';
-
-import { DropDownIcon } from '../icon/index.js';
+import { mergeProps, useFocusRing } from 'react-aria';
 
 import { styles as buttonStyles } from './button.styles.js';
 import { type ButtonProps } from './button.types.js';
@@ -24,6 +22,7 @@ function BaseButton(
   }: ButtonProps,
   ref: any,
 ) {
+  const { isFocusVisible, focusProps } = useFocusRing();
   const iconSize = useMemo(() => getIconSize(size), [size]);
   const styles = buttonStyles({
     size,
@@ -31,16 +30,16 @@ function BaseButton(
     soft,
     block,
     justify,
+    isFocusVisible,
     hasChildren: !!children,
   });
+
   return (
-    <FocusRing focusRingClass="focus-outline">
-      <Tag ref={ref} className={styles.base({ className })} {...props}>
-        {IconBefore && <IconBefore size={iconSize} className={styles.iconBefore()} color={iconColor} />}
-        <span className={styles.text()}>{children}</span>
-        {IconAfter && <IconAfter size={iconSize} className={styles.iconAfter()} color={iconColor} />}
-      </Tag>
-    </FocusRing>
+    <Tag ref={ref} className={styles.base({ className })} {...mergeProps(props, focusProps)}>
+      {IconBefore && <IconBefore size={iconSize} className={styles.iconBefore()} color={iconColor} />}
+      <span className={styles.text()}>{children}</span>
+      {IconAfter && <IconAfter size={iconSize} className={styles.iconAfter()} color={iconColor} />}
+    </Tag>
   );
 }
 

--- a/packages/ui/src/components/button/button.styles.ts
+++ b/packages/ui/src/components/button/button.styles.ts
@@ -37,6 +37,10 @@ export const styles = tv(
       hasChildren: {
         true: '',
       },
+      isFocusVisible: {
+        true: { base: 'focus-outline' },
+        false: { base: 'outline-none' },
+      },
     },
     compoundSlots: [
       {

--- a/packages/ui/src/components/checkbox-group/components/checkbox/checkbox.component.tsx
+++ b/packages/ui/src/components/checkbox-group/components/checkbox/checkbox.component.tsx
@@ -25,8 +25,8 @@ function BaseCheckbox({ className, hint, children, value, ...props }: CheckboxPr
   const { size, orientation } = state;
   const localRef = useRef(null);
   const { inputProps, isDisabled, isSelected } = useCheckboxGroupItem({ ...props, value, children }, state, localRef);
-  const { isFocusVisible, focusProps } = useFocusRing();
-  const styles = checkboxItemStyles({ isDisabled, size, orientation, isFocusVisible });
+  const { isFocused, focusProps } = useFocusRing();
+  const styles = checkboxItemStyles({ isDisabled, size, orientation, isFocused });
 
   return (
     <label className={styles.base({ className })} ref={ref}>

--- a/packages/ui/src/components/checkbox-group/components/checkbox/checkbox.spec.tsx
+++ b/packages/ui/src/components/checkbox-group/components/checkbox/checkbox.spec.tsx
@@ -37,7 +37,7 @@ describe('Checkbox', () => {
   });
 
   it('should have correct styling on focus', () => {
-    const { checkbox } = styles({ isFocusVisible: true });
+    const { checkbox } = styles({ isFocused: true });
 
     expect(checkbox()).toContain('focus-outline');
   });

--- a/packages/ui/src/components/checkbox-group/components/checkbox/checkbox.styles.ts
+++ b/packages/ui/src/components/checkbox-group/components/checkbox/checkbox.styles.ts
@@ -7,8 +7,8 @@ export const styles = tv(
       checkIcon: 'overflow-visible',
       textWrapper: 'flex flex-col justify-center',
       labelText: 'typography-body-10 py-[2px] pl-1',
-      hintText: 'typography-body-10 pl-1 text-muted',
-      checkbox: 'flex h-4 w-4 items-center justify-center rounded border border-hero',
+      hintText: 'typography-body-10 text-muted pl-1',
+      checkbox: 'border-hero flex h-4 w-4 items-center justify-center rounded border',
     },
     variants: {
       isDisabled: {
@@ -20,8 +20,8 @@ export const styles = tv(
           base: 'hover:cursor-pointer',
         },
       },
-      isFocusVisible: {
-        true: { checkbox: 'rounded focus-outline' },
+      isFocused: {
+        true: { checkbox: 'focus-outline' },
       },
       orientation: {
         horizontal: {

--- a/packages/ui/src/components/collapsible/collapsible.styles.ts
+++ b/packages/ui/src/components/collapsible/collapsible.styles.ts
@@ -3,7 +3,7 @@ import { tv } from 'tailwind-variants';
 export const styles = tv(
   {
     slots: {
-      base: 'px-0 text-text no-underline hover:underline focus:focus-outline',
+      base: 'text-text px-0 no-underline hover:underline',
       content: 'typography-body-10 mb-2 block',
     },
     variants: {

--- a/packages/ui/src/components/compacta/compacta.styles.ts
+++ b/packages/ui/src/components/compacta/compacta.styles.ts
@@ -12,7 +12,7 @@ export const styles = tv(
       itemIndex: 'mr-2 w-4 flex-none font-bold',
       removeBtn: 'mt-[0.875rem] h-auto p-0 no-underline hover:underline',
       addBtn: 'h-auto p-0 no-underline hover:underline',
-      toggleBtn: 'focus:outline-focus ml-auto p-0',
+      toggleBtn: 'ml-auto p-0',
       collapsible: '',
       content: 'xsl:pl-[3.375rem] p-[0_1.125rem_1.875rem]',
       footer: 'pt-[0.5rem]',

--- a/packages/ui/src/components/flexi-cell/flexi-cell.component.tsx
+++ b/packages/ui/src/components/flexi-cell/flexi-cell.component.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef } from 'react';
+import { mergeProps, useFocusRing } from 'react-aria';
 
 import { ArrowRightIcon } from '../icon/index.js';
 
@@ -31,9 +32,10 @@ function FlexiCellBase(
   }: FlexiCellProps,
   ref: any,
 ) {
-  const styles = flexiCellStyles({ className, withBorder, isLink: !!href || withHoverEffect });
+  const { isFocusVisible, focusProps } = useFocusRing();
+  const styles = flexiCellStyles({ className, withBorder, isLink: !!href || withHoverEffect, isFocusVisible });
   return (
-    <Tag {...({ ref } as any)} className={styles.base({ className })} href={href} {...props}>
+    <Tag {...({ ref } as any)} className={styles.base({ className })} href={href} {...mergeProps(props, focusProps)}>
       {badge && <div className={styles.badge()}>{badge}</div>}
       {before}
       <div className={styles.bodyWrapper()}>{body ? <FlexiCellBody>{children}</FlexiCellBody> : children}</div>

--- a/packages/ui/src/components/flexi-cell/flexi-cell.spec.tsx
+++ b/packages/ui/src/components/flexi-cell/flexi-cell.spec.tsx
@@ -11,7 +11,7 @@ describe('FlexiCell', () => {
   it('renders the style correctly', () => {
     const style = styles();
     // TODO: use some variants for test
-    expect(style.base()).toBe('relative flex gap-2 bg-white p-2 transition-colors focus:focus-outline md:p-3');
+    expect(style.base()).toBe('relative flex gap-2 bg-white p-2 transition-colors md:p-3');
     expect(style.badge()).toBe('absolute right-0 top-0');
     expect(style.bodyWrapper()).toBe('flex flex-1 flex-col');
   });

--- a/packages/ui/src/components/flexi-cell/flexi-cell.styles.ts
+++ b/packages/ui/src/components/flexi-cell/flexi-cell.styles.ts
@@ -3,14 +3,14 @@ import { tv } from 'tailwind-variants';
 export const styles = tv(
   {
     slots: {
-      base: 'relative flex gap-2 bg-white p-2 transition-colors focus:focus-outline md:p-3',
+      base: 'relative flex gap-2 bg-white p-2 transition-colors md:p-3',
       bodyWrapper: 'flex flex-1 flex-col',
       badge: 'absolute right-0 top-0',
     },
     variants: {
       withBorder: {
         true: {
-          base: 'rounded border border-borderDark',
+          base: 'border-borderDark rounded border',
         },
         false: {},
       },
@@ -19,6 +19,9 @@ export const styles = tv(
           base: 'hover:border-hero',
         },
         false: {},
+      },
+      isFocusVisible: {
+        true: { base: 'focus-outline' },
       },
     },
   },

--- a/packages/ui/src/components/input/input.component.tsx
+++ b/packages/ui/src/components/input/input.component.tsx
@@ -1,4 +1,5 @@
 import React, { ForwardedRef, forwardRef } from 'react';
+import { mergeProps, useFocusRing } from 'react-aria';
 
 import { styles } from './input.styles.js';
 import { type InputProps } from './input.types.js';
@@ -7,7 +8,15 @@ export function BaseInput(
   { className, size = 'medium', invalid = false, ...props }: InputProps,
   ref: ForwardedRef<HTMLInputElement>,
 ) {
-  return <input ref={ref} className={styles({ className, size, invalid })} aria-invalid={invalid} {...props} />;
+  const { isFocused, focusProps } = useFocusRing();
+  return (
+    <input
+      ref={ref}
+      className={styles({ className, size, invalid, isFocused })}
+      aria-invalid={invalid}
+      {...mergeProps(props, focusProps)}
+    />
+  );
 }
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(BaseInput);

--- a/packages/ui/src/components/input/input.spec.tsx
+++ b/packages/ui/src/components/input/input.spec.tsx
@@ -12,7 +12,7 @@ describe('Input', () => {
     const style = styles({ size: 'medium' });
     // TODO: use some variants for test
     expect(style).toBe(
-      'form-control flex-1 read-only:form-control-disabled disabled:form-control-disabled focus:focus-outline group-[.input-field-after]:rounded-r-none group-[.input-field-before]:rounded-l-none group-[.input-field-after]:border-r-0 group-[.input-field-before]:border-l-0 form-control-medium group-[.input-field-inset-after]:pr-7 group-[.input-field-inset-before]:pl-7',
+      'form-control read-only:form-control-disabled disabled:form-control-disabled flex-1 group-[.input-field-after]:rounded-r-none group-[.input-field-before]:rounded-l-none group-[.input-field-after]:border-r-0 group-[.input-field-before]:border-l-0 form-control-medium group-[.input-field-inset-after]:pr-7 group-[.input-field-inset-before]:pl-7',
     );
   });
 });

--- a/packages/ui/src/components/input/input.styles.ts
+++ b/packages/ui/src/components/input/input.styles.ts
@@ -2,7 +2,7 @@ import { tv } from 'tailwind-variants';
 
 export const styles = tv(
   {
-    base: 'form-control flex-1 read-only:form-control-disabled disabled:form-control-disabled focus:focus-outline group-[.input-field-after]:rounded-r-none group-[.input-field-before]:rounded-l-none group-[.input-field-after]:border-r-0 group-[.input-field-before]:border-l-0',
+    base: 'form-control read-only:form-control-disabled disabled:form-control-disabled flex-1 group-[.input-field-after]:rounded-r-none group-[.input-field-before]:rounded-l-none group-[.input-field-after]:border-r-0 group-[.input-field-before]:border-l-0',
     variants: {
       size: {
         small: 'form-control-small group-[.input-field-inset-after]:pr-6 group-[.input-field-inset-before]:pl-6',
@@ -13,6 +13,9 @@ export const styles = tv(
       invalid: {
         true: 'border-danger',
         false: 'border-borderDark',
+      },
+      isFocused: {
+        true: 'focus-outline',
       },
     },
   },

--- a/packages/ui/src/components/link/link.component.tsx
+++ b/packages/ui/src/components/link/link.component.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useRef } from 'react';
-import { useLink } from 'react-aria';
+import { mergeProps, useFocusRing, useLink } from 'react-aria';
 
 import { ArrowRightIcon } from '../icon/index.js';
 
@@ -23,14 +23,21 @@ export function BaseLink(
 ) {
   const ref = useRef(propRef);
   const { linkProps } = useLink({ ...props }, ref);
-  const styles = linkStyles({ type, underline });
+  const { isFocusVisible, focusProps } = useFocusRing();
+  const styles = linkStyles({ type, underline, isFocusVisible });
 
   if (type === 'standalone' && !IconBefore && !IconAfter) {
     IconBefore = ArrowRightIcon;
   }
 
   return (
-    <a {...linkProps} ref={propRef} href={href} target={target} className={styles.base({ className })}>
+    <a
+      {...mergeProps(linkProps, focusProps)}
+      ref={propRef}
+      href={href}
+      target={target}
+      className={styles.base({ className })}
+    >
       {IconBefore && <IconBefore size={iconSize} color="link" className={styles.iconBefore()} />}
       <span className={styles.text()}>{children}</span>
       {IconAfter && <IconAfter size={iconSize} color="link" className={styles.iconAfter()} />}

--- a/packages/ui/src/components/link/link.styles.ts
+++ b/packages/ui/src/components/link/link.styles.ts
@@ -3,7 +3,7 @@ import { tv } from 'tailwind-variants';
 export const styles = tv(
   {
     slots: {
-      base: 'inline-flex bg-[transparent] hover:underline focus:focus-outline',
+      base: 'inline-flex bg-[transparent] hover:underline',
       text: 'typography-body-10',
       iconBefore: 'mr-1',
       iconAfter: 'ml-1',
@@ -11,16 +11,20 @@ export const styles = tv(
     variants: {
       type: {
         inline: {
-          base: 'items-baseline text-link',
+          base: 'text-link items-baseline',
           iconBefore: 'self-center',
           iconAfter: 'self-center',
         },
         standalone: {
-          base: 'items-center text-text',
+          base: 'text-text items-center',
         },
       },
       underline: {
         true: '',
+      },
+      isFocusVisible: {
+        true: { base: 'focus-outline' },
+        false: { base: 'outline-none' },
       },
     },
     compoundSlots: [

--- a/packages/ui/src/components/list/components/item/item.component.tsx
+++ b/packages/ui/src/components/list/components/item/item.component.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef, useContext } from 'react';
+import { useFocusRing } from 'react-aria';
 
 import { ListContext } from '../../list.component.js';
 import { getStateValues } from '../../list.utils.js';
@@ -14,6 +15,7 @@ export function BaseItem({ className, children, href, look, type, spacing, icon,
   look = stateValues.look;
   type = stateValues.type;
   const Icon = stateValues.icon;
+  const { isFocusVisible, focusProps } = useFocusRing();
 
   const styles = itemStyles({
     look,
@@ -21,6 +23,7 @@ export function BaseItem({ className, children, href, look, type, spacing, icon,
     spacing: stateValues.spacing,
     icon: !!Icon,
     nested: (state.nested && state.nested > 0) || false,
+    isFocusVisible,
   });
 
   const bulletToRender = () => {
@@ -38,7 +41,7 @@ export function BaseItem({ className, children, href, look, type, spacing, icon,
       {bulletToRender()}
       <li className={styles.base({ className })} {...props}>
         {type === 'link' ? (
-          <a href={href} className={styles.link()} ref={ref}>
+          <a href={href} className={styles.link()} ref={ref} {...focusProps}>
             {children}
           </a>
         ) : (

--- a/packages/ui/src/components/list/components/item/item.styles.ts
+++ b/packages/ui/src/components/list/components/item/item.styles.ts
@@ -5,7 +5,7 @@ export const styles = tv(
     slots: {
       base: 'typography-body-10 pl-[1.1875rem]',
       bullet: 'absolute block border',
-      link: 'text-text hover:cursor-pointer hover:underline focus:focus-outline',
+      link: 'text-text hover:cursor-pointer hover:underline',
       wrapper: 'relative',
     },
     variants: {
@@ -70,6 +70,9 @@ export const styles = tv(
       },
       nested: {
         true: { bullet: 'bg-[transparent]' },
+      },
+      isFocusVisible: {
+        true: { link: 'focus-outline' },
       },
     },
     compoundSlots: [

--- a/packages/ui/src/components/list/list.stories.tsx
+++ b/packages/ui/src/components/list/list.stories.tsx
@@ -47,9 +47,9 @@ export const ListTypes = () =>
     <div className="mb-2" key={type}>
       <h1 className="typography-body-8">{type}</h1>
       <List type={type} icon={type === 'icon' ? AndroidIcon : undefined}>
-        <List.Item>Styled {type} list</List.Item>
-        <List.Item>Styled {type} list</List.Item>
-        <List.Item>Styled {type} list</List.Item>
+        <List.Item href={type === 'link' ? '#' : undefined}>Styled {type} list</List.Item>
+        <List.Item href={type === 'link' ? '#' : undefined}>Styled {type} list</List.Item>
+        <List.Item href={type === 'link' ? '#' : undefined}>Styled {type} list</List.Item>
         <List icon={type === 'link' ? AndroidIcon : undefined}>
           <List.Item>Styled {type} list</List.Item>
           <List.Item>Styled {type} list</List.Item>

--- a/packages/ui/src/components/modal/components/backdrop/backdrop.styles.ts
+++ b/packages/ui/src/components/modal/components/backdrop/backdrop.styles.ts
@@ -2,7 +2,7 @@ import { tv } from 'tailwind-variants';
 
 export const styles = tv({
   slots: {
-    base: 'fixed inset-0 z-50 flex animate-fadeIn justify-center overflow-y-auto bg-black/50 p-2',
-    modal: 'relative top-5 z-10 h-fit w-full animate-fadeInDown focus:outline-none',
+    base: 'animate-fadeIn fixed inset-0 z-50 flex justify-center overflow-y-auto bg-black/50 p-2',
+    modal: 'animate-fadeInDown relative top-5 z-10 h-fit w-full',
   },
 });

--- a/packages/ui/src/components/modal/components/dialog/dialog.component.tsx
+++ b/packages/ui/src/components/modal/components/dialog/dialog.component.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { useDialog } from 'react-aria';
+import { useDialog, useFocusRing } from 'react-aria';
 
 import { CloseIcon } from '../../../../components/icon/index.js';
 
@@ -10,7 +10,8 @@ import { type DialogProps } from './dialog.types.js';
 
 export function Dialog({ className, body, onClose, size = 'md', ...props }: DialogProps) {
   const { children } = props;
-  const styles = dialogStyles({ className, size });
+  const { isFocusVisible, focusProps } = useFocusRing();
+  const styles = dialogStyles({ className, size, isFocusVisible });
 
   const ref = useRef(null);
 
@@ -19,7 +20,7 @@ export function Dialog({ className, body, onClose, size = 'md', ...props }: Dial
   return (
     <div {...dialogProps} ref={ref} className={styles.base()}>
       {onClose && (
-        <button className={styles.close()} onClick={onClose} aria-label="Close modal">
+        <button className={styles.close()} onClick={onClose} aria-label="Close modal" {...focusProps}>
           <CloseIcon className="block" size="small" />
         </button>
       )}

--- a/packages/ui/src/components/modal/components/dialog/dialog.styles.ts
+++ b/packages/ui/src/components/modal/components/dialog/dialog.styles.ts
@@ -3,9 +3,9 @@ import { tv } from 'tailwind-variants';
 export const styles = tv(
   {
     slots: {
-      base: 'relative mx-auto max-w-full overflow-hidden rounded-[0.1875rem] bg-white focus:focus-outline',
-      title: 'border-b border-b-heading pb-2 pl-4 pr-5 pt-3 text-lg font-medium',
-      close: 'absolute right-1 top-1 block p-1 focus:focus-outline',
+      base: 'relative mx-auto max-w-full overflow-hidden rounded-[0.1875rem] bg-white outline-none',
+      title: 'border-b-heading border-b pb-2 pl-4 pr-5 pt-3 text-lg font-medium',
+      close: 'absolute right-1 top-1 block p-1',
     },
     variants: {
       size: {
@@ -18,6 +18,10 @@ export const styles = tv(
         sm: {
           base: 'w-[18.75rem]',
         },
+      },
+      isFocusVisible: {
+        true: { close: 'focus-outline' },
+        false: { close: 'outline-none' },
       },
     },
   },

--- a/packages/ui/src/components/popover/components/panel/panel.styles.ts
+++ b/packages/ui/src/components/popover/components/panel/panel.styles.ts
@@ -7,7 +7,7 @@ export const styles = tv(
       popover: 'border-muted absolute z-[999] rounded-[3px] border bg-white shadow-[0_5px_10px_rgba(0,0,0,0.2)]',
       arrow:
         'border-t-muted absolute h-0 w-0 border-x-[8px] border-t-[12px] border-x-[transparent] after:absolute after:h-0 after:w-0 after:border-x-[7px] after:border-t-[11px] after:border-x-[transparent] after:border-t-white',
-      closeBtn: 'focus:focus-outline absolute right-1 top-1 m-1 p-0 hover:opacity-80',
+      closeBtn: 'absolute right-1 top-1 m-1 p-0 hover:opacity-80',
       content: 'w-[17.625rem] py-4 pl-3 pr-5',
       heading: 'typography-body-9 mb-2 font-bold',
       body: 'typography-body-10',

--- a/packages/ui/src/components/popover/popover.component.tsx
+++ b/packages/ui/src/components/popover/popover.component.tsx
@@ -47,7 +47,6 @@ export function Popover({
       <Button
         look={icon && !children ? 'link' : look}
         iconAfter={icon}
-        className={styles.button()}
         aria-expanded={state.isOpen}
         aria-controls={panelId}
         onClick={handleClick}

--- a/packages/ui/src/components/popover/popover.styles.ts
+++ b/packages/ui/src/components/popover/popover.styles.ts
@@ -4,7 +4,6 @@ export const styles = tv(
   {
     slots: {
       base: 'relative inline-block',
-      button: 'focus:focus-outline',
     },
     variants: {},
   },

--- a/packages/ui/src/components/radio-group/components/radio/radio.component.tsx
+++ b/packages/ui/src/components/radio-group/components/radio/radio.component.tsx
@@ -11,8 +11,8 @@ function BaseRadio({ className, hint, children, ...props }: RadioProps, ref: any
   const { size, orientation } = state;
   const localRef = useRef(null);
   const { inputProps, isSelected, isDisabled } = useRadio({ ...props, children }, state, localRef);
-  const { isFocusVisible, focusProps } = useFocusRing();
-  const styles = radioStyles({ isDisabled, isSelected, isFocusVisible, size, orientation });
+  const { isFocused, focusProps } = useFocusRing();
+  const styles = radioStyles({ isDisabled, isSelected, isFocused, size, orientation });
 
   return (
     <label className={styles.base({ className })} ref={ref}>

--- a/packages/ui/src/components/radio-group/components/radio/radio.spec.tsx
+++ b/packages/ui/src/components/radio-group/components/radio/radio.spec.tsx
@@ -37,7 +37,7 @@ describe('Radio', () => {
   });
 
   it('should have correct styling on focus', () => {
-    const { selector } = styles({ isFocusVisible: true });
+    const { selector } = styles({ isFocused: true });
 
     expect(selector()).toContain('focus-outline');
   });

--- a/packages/ui/src/components/radio-group/components/radio/radio.styles.ts
+++ b/packages/ui/src/components/radio-group/components/radio/radio.styles.ts
@@ -6,8 +6,8 @@ export const styles = tv(
       base: 'flex',
       textWrapper: 'flex flex-col justify-center',
       labelText: 'typography-body-10 py-[2px] pl-1',
-      hintText: 'typography-body-10 pl-1 text-muted',
-      selector: 'flex h-4 w-4 items-center justify-center rounded-full border border-hero',
+      hintText: 'typography-body-10 text-muted pl-1',
+      selector: 'border-hero flex h-4 w-4 items-center justify-center rounded-full border',
     },
     variants: {
       isDisabled: {
@@ -21,11 +21,11 @@ export const styles = tv(
       },
       isSelected: {
         true: {
-          selector: 'before:block before:h-2 before:w-2 before:rounded-full before:bg-hero',
+          selector: 'before:bg-hero before:block before:h-2 before:w-2 before:rounded-full',
         },
       },
-      isFocusVisible: {
-        true: { selector: 'rounded-full focus-outline' },
+      isFocused: {
+        true: { selector: 'focus-outline' },
       },
       orientation: {
         horizontal: {

--- a/packages/ui/src/components/repeater/repeater.component.tsx
+++ b/packages/ui/src/components/repeater/repeater.component.tsx
@@ -1,5 +1,6 @@
 import { AnimatePresence, LazyMotion, m } from 'framer-motion';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useFocusRing } from 'react-aria';
 
 import { generateID } from '../../utils/index.js';
 import { Button } from '../button/index.js';
@@ -28,6 +29,7 @@ export function Repeater({
   const [action, setAction] = useState<Action>({ type: '', index: 0 });
   const [status, setStatus] = useState('');
   const refArr = useRef<HTMLElement[]>([]);
+  const { isFocused, focusProps } = useFocusRing();
 
   const handleAdd = useCallback(() => {
     setItems([...items, { id: generateID() }]);
@@ -58,7 +60,7 @@ export function Repeater({
   }, [items.length, action]);
 
   const Tag = separator ? 'ol' : 'ul';
-  const styles = repeaterStyles({ separator });
+  const styles = repeaterStyles({ separator, isFocused });
 
   return (
     <div className={styles.base({ className })}>
@@ -80,6 +82,7 @@ export function Repeater({
                     }}
                     tabIndex={-1}
                     className={styles.item()}
+                    {...focusProps}
                   >
                     {separator && <ItemIndex className={styles.itemIndex()}>{index + 1}.</ItemIndex>}
                     <div className={styles.content()}>{children}</div>

--- a/packages/ui/src/components/repeater/repeater.styles.ts
+++ b/packages/ui/src/components/repeater/repeater.styles.ts
@@ -5,7 +5,7 @@ export const styles = tv(
     slots: {
       base: '',
       list: 'm-0 list-none pl-0',
-      item: 'relative focus:outline-none',
+      item: 'relative',
       itemIndex: 'mb-[1.125rem] font-bold',
       content: '',
       removeBtn: 'absolute right-0 top-0 h-auto p-0 no-underline hover:underline',
@@ -19,6 +19,11 @@ export const styles = tv(
           content: 'p-[0_1.125rem_2.625rem]',
           removeBtn: 'relative m-[0_0_1.875rem_1.125rem]',
           footer: 'border-neutral border-t-2 pt-[0.875rem]',
+        },
+      },
+      isFocused: {
+        true: {
+          item: 'outline-none',
         },
       },
     },

--- a/packages/ui/src/components/select/select.component.tsx
+++ b/packages/ui/src/components/select/select.component.tsx
@@ -1,4 +1,5 @@
 import React, { ForwardedRef, forwardRef } from 'react';
+import { mergeProps, useFocusRing } from 'react-aria';
 
 import { styles } from './select.styles.js';
 import { type SelectProps } from './select.types.js';
@@ -7,8 +8,9 @@ function BaseSelect(
   { className, size = 'medium', invalid = false, children, ...props }: SelectProps,
   ref: ForwardedRef<HTMLSelectElement>,
 ) {
+  const { isFocused, focusProps } = useFocusRing();
   return (
-    <select ref={ref} className={styles({ className, size, invalid })} {...props}>
+    <select ref={ref} className={styles({ className, size, invalid, isFocused })} {...mergeProps(props, focusProps)}>
       {children}
     </select>
   );

--- a/packages/ui/src/components/select/select.spec.tsx
+++ b/packages/ui/src/components/select/select.spec.tsx
@@ -12,7 +12,7 @@ describe('Select', () => {
     const style = styles({ size: 'medium' });
     // TODO: use some variants for test
     expect(style).toBe(
-      'form-control bg-no-repeat select-caret disabled:form-control-disabled focus:focus-outline group-[.add-on-after]:rounded-l-none group-[.add-on-before]:rounded-r-none form-control-medium bg-[right_0.75rem_center] pr-[calc(0.5rem+14px+0.75rem)]',
+      'form-control select-caret disabled:form-control-disabled bg-no-repeat group-[.add-on-after]:rounded-l-none group-[.add-on-before]:rounded-r-none form-control-medium bg-[right_0.75rem_center] pr-[calc(0.5rem+14px+0.75rem)]',
     );
   });
 });

--- a/packages/ui/src/components/select/select.styles.ts
+++ b/packages/ui/src/components/select/select.styles.ts
@@ -2,7 +2,7 @@ import { tv } from 'tailwind-variants';
 
 export const styles = tv(
   {
-    base: 'form-control bg-no-repeat select-caret disabled:form-control-disabled focus:focus-outline group-[.add-on-after]:rounded-l-none group-[.add-on-before]:rounded-r-none',
+    base: 'form-control select-caret disabled:form-control-disabled bg-no-repeat group-[.add-on-after]:rounded-l-none group-[.add-on-before]:rounded-r-none',
     variants: {
       size: {
         small: 'form-control-small bg-[right_0.5625rem_center] pr-[calc(0.5rem+14px+0.5625rem)]',
@@ -13,6 +13,11 @@ export const styles = tv(
       invalid: {
         true: 'border-danger',
         false: 'border-borderDark',
+      },
+      isFocused: {
+        true: {
+          base: 'focus-outline',
+        },
       },
     },
   },

--- a/packages/ui/src/components/selector/components/selector-checkbox-group/components/selector-checkbox-group-option/selector-checkbox-group-option.component.tsx
+++ b/packages/ui/src/components/selector/components/selector-checkbox-group/components/selector-checkbox-group-option/selector-checkbox-group-option.component.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useContext, useRef } from 'react';
-import { VisuallyHidden, useCheckboxGroupItem, useFocusRing } from 'react-aria';
+import { VisuallyHidden, mergeProps, useCheckboxGroupItem, useFocusRing } from 'react-aria';
 
 import {
   FlexiCellAdornment,
@@ -37,11 +37,11 @@ function BaseSelectorCheckboxGroupOption(
   const state = useContext(SelectorCheckboxGroupContext);
   const localRef = useRef(null);
   const { inputProps, isDisabled, isSelected } = useCheckboxGroupItem({ ...props, value, children }, state, localRef);
-  const { isFocusVisible, focusProps } = useFocusRing();
+  const { isFocused, focusProps } = useFocusRing();
   const styles = selectorCheckboxGroupOptionStyles({
     className,
     isSelected,
-    isFocusVisible,
+    isFocused,
     isDisabled,
     checkIcon,
   });
@@ -68,7 +68,7 @@ function BaseSelectorCheckboxGroupOption(
       className={styles.base({})}
     >
       <VisuallyHidden>
-        <input {...inputProps} {...focusProps} ref={localRef} />
+        <input {...mergeProps(inputProps, focusProps)} ref={localRef} />
       </VisuallyHidden>
       {children}
     </FlexiCell>

--- a/packages/ui/src/components/selector/components/selector-checkbox-group/components/selector-checkbox-group-option/selector-checkbox-group-option.styles.ts
+++ b/packages/ui/src/components/selector/components/selector-checkbox-group/components/selector-checkbox-group-option/selector-checkbox-group-option.styles.ts
@@ -19,7 +19,7 @@ export const styles = tv(
         },
         false: {},
       },
-      isFocusVisible: {
+      isFocused: {
         true: {
           base: 'focus-outline',
         },

--- a/packages/ui/src/components/selector/components/selector-radio-group/components/selector-radio-group-option/selector-radio-group-option.component.tsx
+++ b/packages/ui/src/components/selector/components/selector-radio-group/components/selector-radio-group-option/selector-radio-group-option.component.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, useContext, useRef } from 'react';
-import { VisuallyHidden, useFocusRing, useRadio } from 'react-aria';
+import { VisuallyHidden, mergeProps, useFocusRing, useRadio } from 'react-aria';
 
 import {
   FlexiCellAdornment,
@@ -37,8 +37,8 @@ function BaseSelectorRadioGroupOption(
   const state = useContext(SelectorRadioGroupContext);
   const localRef = useRef(null);
   const { inputProps, isSelected, isDisabled } = useRadio({ ...props, value, children }, state, localRef);
-  const { isFocusVisible, focusProps } = useFocusRing();
-  const styles = selectorRadioGroupOptionStyles({ className, isSelected, isFocusVisible, isDisabled, checkIcon });
+  const { isFocused, focusProps } = useFocusRing();
+  const styles = selectorRadioGroupOptionStyles({ className, isSelected, isFocused, isDisabled, checkIcon });
 
   const FinalIcon = checkIcon === 'checkbox' ? TickIcon : ArrowRightIcon;
 
@@ -62,7 +62,7 @@ function BaseSelectorRadioGroupOption(
       withHoverEffect
     >
       <VisuallyHidden>
-        <input {...inputProps} {...focusProps} ref={localRef} />
+        <input {...mergeProps(inputProps, focusProps)} ref={localRef} />
       </VisuallyHidden>
       {children}
     </FlexiCell>

--- a/packages/ui/src/components/selector/components/selector-radio-group/components/selector-radio-group-option/selector-radio-group-option.styles.ts
+++ b/packages/ui/src/components/selector/components/selector-radio-group/components/selector-radio-group-option/selector-radio-group-option.styles.ts
@@ -15,11 +15,11 @@ export const styles = tv(
       },
       isSelected: {
         true: {
-          base: 'border-hero shadow-[0_0_0_2px_inset] shadow-hero',
+          base: 'border-hero shadow-hero shadow-[0_0_0_2px_inset]',
         },
         false: {},
       },
-      isFocusVisible: {
+      isFocused: {
         true: {
           base: 'focus-outline',
         },

--- a/packages/ui/src/components/switch/switch.component.tsx
+++ b/packages/ui/src/components/switch/switch.component.tsx
@@ -1,18 +1,30 @@
 import React, { useId, useRef } from 'react';
-import { VisuallyHidden, useCheckbox, useFocusRing } from 'react-aria';
+import { VisuallyHidden, mergeProps, useCheckbox, useFocusRing } from 'react-aria';
 import { useToggleState } from 'react-stately';
 
 import { styles as switchStyles } from './switch.styles.js';
 import { type SwitchProps } from './switch.types.js';
 
-export function Switch({ className, label, size = 'medium', block = false, isDisabled, ...props }: SwitchProps) {
-  const state = useToggleState(props);
+export function Switch({
+  className,
+  label,
+  size = 'medium',
+  block = false,
+  checked = false,
+  isDisabled,
+  ...props
+}: SwitchProps) {
+  const state = useToggleState({ ...props, defaultSelected: checked });
   const labelId = useId();
   const ref = useRef(null);
-  const { inputProps } = useCheckbox({ isDisabled, 'aria-labelledby': labelId, ...props }, state, ref);
   const { isSelected } = state;
-  const { isFocusVisible, focusProps } = useFocusRing();
-  const styles = switchStyles({ block, isFocusVisible, isSelected, isDisabled, size });
+  const { inputProps } = useCheckbox(
+    { isDisabled, 'aria-labelledby': labelId, defaultSelected: checked, ...props },
+    state,
+    ref,
+  );
+  const { isFocused, focusProps } = useFocusRing();
+  const styles = switchStyles({ block, isFocused, isSelected, isDisabled, size });
 
   return (
     <label className={styles.base({ className })}>
@@ -20,7 +32,7 @@ export function Switch({ className, label, size = 'medium', block = false, isDis
         {label}
       </span>
       <VisuallyHidden>
-        <input {...inputProps} {...focusProps} ref={ref} />
+        <input {...mergeProps(inputProps, focusProps)} ref={ref} />
       </VisuallyHidden>
       <div className={styles.switchDiv()} />
     </label>

--- a/packages/ui/src/components/switch/switch.stories.tsx
+++ b/packages/ui/src/components/switch/switch.stories.tsx
@@ -39,7 +39,7 @@ export const DefaultStory: Story = {
 export const SelectedSwitch: Story = {
   args: {
     label: 'eStatements',
-    isSelected: true,
+    checked: true,
   },
 };
 

--- a/packages/ui/src/components/switch/switch.styles.ts
+++ b/packages/ui/src/components/switch/switch.styles.ts
@@ -5,7 +5,7 @@ export const styles = tv(
     slots: {
       base: 'mb-1 inline-flex items-center hover:cursor-pointer',
       switchDiv:
-        'relative box-content overflow-hidden border border-borderDark transition duration-[.3s] after:absolute after:left-0 after:top-0 after:block after:rounded-[50%] after:bg-white after:shadow-switch after:transition-all after:duration-[.3s]',
+        'border-borderDark after:shadow-switch relative box-content overflow-hidden border transition duration-[.3s] after:absolute after:left-0 after:top-0 after:block after:rounded-[50%] after:bg-white after:transition-all after:duration-[.3s]',
       label: 'pr-1',
     },
     variants: {
@@ -23,7 +23,7 @@ export const styles = tv(
           switchDiv: 'h-[2.875rem] w-14 rounded-[2.875rem] after:h-[2.875rem] after:w-[2.875rem]',
         },
       },
-      isFocusVisible: {
+      isFocused: {
         true: {
           switchDiv: 'focus-outline',
         },

--- a/packages/ui/src/components/switch/switch.types.ts
+++ b/packages/ui/src/components/switch/switch.types.ts
@@ -9,6 +9,10 @@ export type SwitchProps = {
    */
   block?: boolean;
   /**
+   * Default checked
+   */
+  checked?: boolean;
+  /**
    * Classname for overriding base style
    */
   className?: string;
@@ -16,5 +20,5 @@ export type SwitchProps = {
    * Label for the switch
    */
   label: string;
-} & Omit<AriaCheckboxProps, 'children'> &
+} & Omit<AriaCheckboxProps, 'children' | 'isSelected'> &
   Pick<VariantProps<typeof styles>, 'size'>;

--- a/packages/ui/src/components/tabs/components/tab-panel/tab-panel.component.tsx
+++ b/packages/ui/src/components/tabs/components/tab-panel/tab-panel.component.tsx
@@ -1,14 +1,15 @@
 import React, { useRef } from 'react';
-import { useTabPanel } from 'react-aria';
+import { mergeProps, useFocusRing, useTabPanel } from 'react-aria';
 
 import { styles } from './tab-panel.styles.js';
 import { type TabPanelProps } from './tab-panel.types.js';
 
 export function TabPanel({ className, state, look, ...props }: TabPanelProps) {
   const ref = useRef(null);
+  const { isFocused, focusProps } = useFocusRing();
   const { tabPanelProps } = useTabPanel({ ...props }, state, ref);
   return (
-    <div {...tabPanelProps} ref={ref} className={styles({ className, look })}>
+    <div {...mergeProps(tabPanelProps, focusProps)} ref={ref} className={styles({ className, look, isFocused })}>
       {state.selectedItem?.props.children}
     </div>
   );

--- a/packages/ui/src/components/tabs/components/tab-panel/tab-panel.styles.ts
+++ b/packages/ui/src/components/tabs/components/tab-panel/tab-panel.styles.ts
@@ -2,11 +2,14 @@ import { tv } from 'tailwind-variants';
 
 export const styles = tv(
   {
-    base: 'flex-1 bg-white p-4 focus:focus-outline',
+    base: 'flex-1 bg-white p-4',
     variants: {
       look: {
-        default: 'border border-border',
+        default: 'border-border border',
         material: '',
+      },
+      isFocused: {
+        true: 'outline-none',
       },
     },
   },

--- a/packages/ui/src/components/tabs/components/tab/tab.component.tsx
+++ b/packages/ui/src/components/tabs/components/tab/tab.component.tsx
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react';
-import { useTab } from 'react-aria';
+import { mergeProps, useFocusRing, useTab } from 'react-aria';
 
 import { styles } from './tab.styles.js';
 import { type TabProps } from './tab.types.js';
@@ -7,10 +7,11 @@ import { type TabProps } from './tab.types.js';
 export function Tab({ item: { key, rendered }, state, orientation, justify, color, look }: TabProps) {
   const ref = useRef(null);
   const { tabProps } = useTab({ key }, state, ref);
+  const { isFocusVisible, focusProps } = useFocusRing();
   return (
     <div
-      {...tabProps}
-      className={styles({ selected: key === state.selectedKey, orientation, justify, color, look })}
+      {...mergeProps(tabProps, focusProps)}
+      className={styles({ selected: key === state.selectedKey, orientation, justify, color, look, isFocusVisible })}
       ref={ref}
     >
       {rendered}

--- a/packages/ui/src/components/tabs/components/tab/tab.styles.ts
+++ b/packages/ui/src/components/tabs/components/tab/tab.styles.ts
@@ -2,10 +2,10 @@ import { tv } from 'tailwind-variants';
 
 export const styles = tv(
   {
-    base: 'typography-body-9 flex cursor-pointer px-3 py-2 text-text transition-colors hover:bg-white focus:focus-outline',
+    base: 'typography-body-9 text-text flex cursor-pointer px-3 py-2 transition-colors hover:bg-white',
     variants: {
       look: {
-        default: 'border border-border bg-white',
+        default: 'border-border border bg-white',
         material: '',
       },
       selected: {
@@ -22,6 +22,10 @@ export const styles = tv(
       color: {
         primary: '',
         hero: '',
+      },
+      isFocusVisible: {
+        true: 'focus-outline',
+        false: 'outline-none',
       },
     },
     compoundVariants: [
@@ -54,36 +58,36 @@ export const styles = tv(
         color: 'primary',
         look: 'default',
         selected: false,
-        className: 'border-primary-90 bg-primary text-white hover:bg-primary-70',
+        className: 'border-primary-90 bg-primary hover:bg-primary-70 text-white',
       },
       {
         color: 'hero',
         selected: false,
         look: 'default',
-        className: 'border-hero-90 bg-hero text-white hover:bg-hero-70',
+        className: 'border-hero-90 bg-hero hover:bg-hero-70 text-white',
       },
       // Material look design
       {
         look: 'material',
         orientation: 'horizontal',
-        className: 'border-b-4 border-r border-b-white border-r-border last:border-r-0',
+        className: 'border-r-border border-b-4 border-r border-b-white last:border-r-0',
       },
       {
         look: 'material',
         orientation: 'vertical',
-        className: 'border-b border-l-4 border-b-border border-l-white last:border-b-0',
+        className: 'border-b-border border-b border-l-4 border-l-white last:border-b-0',
       },
       {
         look: 'material',
         selected: true,
         orientation: 'horizontal',
-        className: 'border-bottom border-b-white text-text',
+        className: 'border-bottom text-text border-b-white',
       },
       {
         look: 'material',
         selected: true,
         orientation: 'vertical',
-        className: 'border-left border-l-transparent text-text',
+        className: 'border-left text-text border-l-transparent',
       },
       {
         color: 'primary',

--- a/packages/ui/src/components/textarea/textarea.component.tsx
+++ b/packages/ui/src/components/textarea/textarea.component.tsx
@@ -1,4 +1,5 @@
 import React, { ForwardedRef, forwardRef } from 'react';
+import { mergeProps, useFocusRing } from 'react-aria';
 
 import { styles } from './textarea.styles.js';
 import { type TextareaProps } from './textarea.types.js';
@@ -7,7 +8,14 @@ function BaseTextarea(
   { className, size = 'medium', invalid = false, ...props }: TextareaProps,
   ref: ForwardedRef<HTMLTextAreaElement>,
 ) {
-  return <textarea ref={ref} className={styles({ className, size, invalid })} {...props} />;
+  const { isFocused, focusProps } = useFocusRing();
+  return (
+    <textarea
+      ref={ref}
+      className={styles({ className, size, invalid, isFocused })}
+      {...mergeProps(props, focusProps)}
+    />
+  );
 }
 
 export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(BaseTextarea);

--- a/packages/ui/src/components/textarea/textarea.spec.tsx
+++ b/packages/ui/src/components/textarea/textarea.spec.tsx
@@ -12,7 +12,7 @@ describe('Textarea', () => {
     const style = styles({ size: 'medium' });
     // TODO: use some variants for test
     expect(style).toBe(
-      'form-control w-full read-only:form-control-disabled disabled:form-control-disabled focus:focus-outline form-control-medium min-h-[3.375rem]',
+      'form-control read-only:form-control-disabled disabled:form-control-disabled w-full form-control-medium min-h-[3.375rem]',
     );
   });
 });

--- a/packages/ui/src/components/textarea/textarea.styles.ts
+++ b/packages/ui/src/components/textarea/textarea.styles.ts
@@ -2,7 +2,7 @@ import { tv } from 'tailwind-variants';
 
 export const styles = tv(
   {
-    base: 'form-control w-full read-only:form-control-disabled disabled:form-control-disabled focus:focus-outline',
+    base: 'form-control read-only:form-control-disabled disabled:form-control-disabled w-full',
     variants: {
       size: {
         small: 'form-control-small min-h-[3.375rem]',
@@ -13,6 +13,9 @@ export const styles = tv(
       invalid: {
         true: 'border-danger',
         false: 'border-borderDark',
+      },
+      isFocused: {
+        true: 'focus-outline',
       },
     },
   },


### PR DESCRIPTION
- any use of focus: in tailwind styling for a focus ring/outline has been changed to use useFocusRing()
- re-ordered styles
- changed tests to reflects re-ordered styles
- some minor changes to a couple of components as they weren't working as intended (Switch checked for example)