### PR TITLE
Fixes/input group input responsive widths

### DIFF
--- a/.changeset/witty-terms-compare.md
+++ b/.changeset/witty-terms-compare.md
@@ -1,0 +1,5 @@
+---
+"@westpac/ui": patch
+---
+
+fixed a bug with input group not passing responsive input widths to child inputs correctly

--- a/.changeset/witty-terms-compare.md
+++ b/.changeset/witty-terms-compare.md
@@ -1,5 +1,5 @@
 ---
-"@westpac/ui": patch
+'@westpac/ui': patch
 ---
 
 fixed a bug with input group not passing responsive input widths to child inputs correctly

--- a/packages/ui/src/components/input-group/input-group.component.tsx
+++ b/packages/ui/src/components/input-group/input-group.component.tsx
@@ -102,7 +102,7 @@ export function InputGroup({
     after: !!after,
     afterInset,
     beforeInset,
-    width: !isNaN(Number(width)),
+    width: width,
   });
 
   return (

--- a/packages/ui/src/components/input-group/input-group.stories.tsx
+++ b/packages/ui/src/components/input-group/input-group.stories.tsx
@@ -178,6 +178,19 @@ export const FixedWidths = () => {
           </Autocomplete>
         </InputGroup>
       ))}
+      <h3 className="typography-body-7 mb-3">Responsive input widths</h3>
+      <InputGroup
+        key="responsive width"
+        tag="fieldset"
+        label="Label"
+        hint="I am a hint"
+        supportingText="I am supporting text"
+        after={<Button>Check</Button>}
+        before="$AUD"
+        width={{ initial: 'full', sm: 10, md: 20, lg: 30 }}
+      >
+        <Input placeholder="responsive" />
+      </InputGroup>
     </div>
   );
 };

--- a/packages/ui/src/components/input-group/input-group.styles.ts
+++ b/packages/ui/src/components/input-group/input-group.styles.ts
@@ -1,5 +1,6 @@
 import { tv } from 'tailwind-variants';
 
+const inlineFlexInput = { input: 'inline-flex' };
 export const styles = tv(
   {
     slots: {
@@ -23,9 +24,21 @@ export const styles = tv(
         true: '',
         false: '',
       },
+      // Has to be done this as doing it with compoundVariants with array was not working
       width: {
-        true: '',
-        false: '',
+        full: '',
+        1: inlineFlexInput,
+        2: inlineFlexInput,
+        3: inlineFlexInput,
+        4: inlineFlexInput,
+        5: inlineFlexInput,
+        6: inlineFlexInput,
+        7: inlineFlexInput,
+        8: inlineFlexInput,
+        9: inlineFlexInput,
+        10: inlineFlexInput,
+        20: inlineFlexInput,
+        30: inlineFlexInput,
       },
     },
     compoundVariants: [
@@ -48,12 +61,6 @@ export const styles = tv(
         before: true,
         beforeInset: true,
         className: { base: 'input-group-inset-before' },
-      },
-      {
-        width: true,
-        className: {
-          input: 'inline-flex',
-        },
       },
     ],
   },


### PR DESCRIPTION
- fixed a bug where responsive widths were not getting passed to child inputs in input group
- added an example of responsive widths to storybook for input group widths