### PR TITLE
Feature/list: add linkTag to ListItem

### DIFF
--- a/.changeset/weak-tomatoes-wave.md
+++ b/.changeset/weak-tomatoes-wave.md
@@ -1,0 +1,5 @@
+---
+'@westpac/ui': minor
+---
+
+List component with custom component tag

--- a/packages/ui/src/components/list/components/list-item/list-item.component.tsx
+++ b/packages/ui/src/components/list/components/list-item/list-item.component.tsx
@@ -10,7 +10,7 @@ import { styles as itemStyles } from './list-item.styles.js';
 import { type ListItemProps } from './list-item.types.js';
 
 export function BaseListItem(
-  { className, children, href, target, look, type, spacing, icon, ...props }: ListItemProps,
+  { className, linkTag: LinkTag = 'a', children, href, target, look, type, spacing, icon, ...props }: ListItemProps,
   ref: Ref<HTMLAnchorElement>,
 ) {
   const state = useContext(ListContext);
@@ -45,9 +45,9 @@ export function BaseListItem(
     <li className={styles.base({ className })} {...props} key={state.nested}>
       {bulletToRender()}
       {type === 'link' ? (
-        <a href={href} target={target} className={styles.link()} ref={ref} {...focusProps}>
+        <LinkTag href={href} target={target} className={styles.link()} ref={ref} {...focusProps}>
           {children}
-        </a>
+        </LinkTag>
       ) : (
         children
       )}

--- a/packages/ui/src/components/list/components/list-item/list-item.types.ts
+++ b/packages/ui/src/components/list/components/list-item/list-item.types.ts
@@ -1,4 +1,4 @@
-import { HTMLAttributeAnchorTarget, HTMLAttributes, ReactNode } from 'react';
+import { HTMLAttributeAnchorTarget, HTMLAttributes, ReactElement, ReactNode } from 'react';
 
 import { IconProps } from '../../../icon/index.js';
 
@@ -15,6 +15,10 @@ export type ListItemProps = {
    * The icon for list item
    */
   icon?: (props: IconProps) => JSX.Element;
+  /**
+   * Link tag to render
+   */
+  linkTag?: keyof JSX.IntrinsicElements | ((...args: any[]) => ReactElement | null);
   /**
    * The look of the bullet, icon, tick and cross lists
    */

--- a/packages/ui/src/components/list/components/list-item/list-item.types.ts
+++ b/packages/ui/src/components/list/components/list-item/list-item.types.ts
@@ -18,7 +18,7 @@ export type ListItemProps = {
   /**
    * Link tag to render
    */
-  linkTag?: keyof JSX.IntrinsicElements | ((...args: any[]) => ReactElement | null);
+  linkTag?: 'a' | ((...args: any[]) => ReactElement | null);
   /**
    * The look of the bullet, icon, tick and cross lists
    */

--- a/packages/ui/src/components/list/list.stories.tsx
+++ b/packages/ui/src/components/list/list.stories.tsx
@@ -135,9 +135,15 @@ export const CustomComponent = () => (
   <div>
     <h1 className="typography-body-10 mb-2">Title</h1>
     <List type="link" className="mb-4" spacing="medium">
-      <ListItem linkTag={CustomLink}>Styled bullet list</ListItem>
-      <ListItem linkTag={CustomLink}>Styled bullet list</ListItem>
-      <ListItem linkTag={CustomLink}>Styled bullet list</ListItem>
+      <ListItem linkTag={CustomLink} href="#href1">
+        Styled bullet list
+      </ListItem>
+      <ListItem linkTag={CustomLink} href="#href2">
+        Styled bullet list
+      </ListItem>
+      <ListItem linkTag={CustomLink} href="#href3">
+        Styled bullet list
+      </ListItem>
     </List>
   </div>
 );

--- a/packages/ui/src/components/list/list.stories.tsx
+++ b/packages/ui/src/components/list/list.stories.tsx
@@ -121,3 +121,23 @@ export const Spacing = () => (
     </List>
   </div>
 );
+
+const CustomLink = (props: any) => {
+  // eslint-disable-next-line no-console
+  console.info('TEST');
+  return <a {...props}>{props.children}</a>;
+};
+
+/**
+ * Custom Component
+ */
+export const CustomComponent = () => (
+  <div>
+    <h1 className="typography-body-10 mb-2">Title</h1>
+    <List type="link" className="mb-4" spacing="medium">
+      <ListItem linkTag={CustomLink}>Styled bullet list</ListItem>
+      <ListItem linkTag={CustomLink}>Styled bullet list</ListItem>
+      <ListItem linkTag={CustomLink}>Styled bullet list</ListItem>
+    </List>
+  </div>
+);


### PR DESCRIPTION
issue:
![image](https://github.com/user-attachments/assets/c5685be1-f943-446b-ba86-2a4b81589518)

expected:
<img width="212" alt="image" src="https://github.com/user-attachments/assets/cb1ff64d-7f3c-4883-a387-b2074834aba6">

In order to render the component with the style and functionality of `@mep-ui/framework-router-addon` I added the prop `tagLink` where we can pass the CustomComponent that will be rendered in place of `<a />`


