### PR TITLE
#1020 unstyled popover with customised look

### DIFF
--- a/.changeset/nice-dragons-smoke.md
+++ b/.changeset/nice-dragons-smoke.md
@@ -1,0 +1,5 @@
+---
+'@westpac/ui': patch
+---
+
+unstyled inline popover with customised look must not have padding and trigger button should have text left aligned to look cool in small screens

--- a/packages/ui/src/components/popover/popover.component.tsx
+++ b/packages/ui/src/components/popover/popover.component.tsx
@@ -32,7 +32,7 @@ export function Popover({
 }: PopoverProps) {
   const state = useOverlayTriggerState({});
   const panelId = useId();
-  const styles = popoverStyles({ linkStyling });
+  const styles = popoverStyles({ linkStyling, look });
   const ref = useRef<HTMLButtonElement & HTMLAnchorElement & HTMLSpanElement & HTMLDivElement>(null);
 
   const handleClick = useCallback(

--- a/packages/ui/src/components/popover/popover.stories.tsx
+++ b/packages/ui/src/components/popover/popover.stories.tsx
@@ -101,6 +101,34 @@ export const AsInlineLinkAppearance = () => (
 );
 
 /**
+ * > Popover trigger as inline unstyled appearance
+ */
+export const AsInlineUnstyledAppearance = () => (
+  <>
+    <h3 className="typography-body-7 mb-2 font-bold">Inside Accordian/Paragraph</h3>
+    <p className="mb-4">
+      {' '}
+      This is an example of using a popover that looks like an inline customised underling decoration{' '}
+      <Popover look="unstyled" heading="Heading" content={popoverContent} size="small">
+        <span className="underline decoration-dotted decoration-[1.5px]">Click here.</span>
+      </Popover>{' '}
+      To test popover.
+    </p>
+
+    <p className="mb-4">
+      {' '}
+      This is an example of using a popover that looks like an inline customised underling decoration and name is way
+      big and screen size is small{' '}
+      <Popover look="unstyled" heading="Heading" content={popoverContent} size="small">
+        <span className="underline decoration-dotted decoration-[1.5px]">
+          THE ELIZABETH COLLEGE OF TECHNOLOG MARK CHARLES HOOKWAY AND MADDALENA limited.
+        </span>
+      </Popover>{' '}
+    </p>
+  </>
+);
+
+/**
  * > Popover trigger as inline link appearance
  */
 export const StackingOrderWithPortal = () => (

--- a/packages/ui/src/components/popover/popover.styles.ts
+++ b/packages/ui/src/components/popover/popover.styles.ts
@@ -16,8 +16,13 @@ export const styles = tv(
       look: {
         unstyled: {
           button: 'p-0 text-left',
-          false: {},
         },
+        link: {
+          button: 'p-0 text-left',
+        },
+        primary: {},
+        hero: {},
+        faint: {},
       },
     },
   },

--- a/packages/ui/src/components/popover/popover.styles.ts
+++ b/packages/ui/src/components/popover/popover.styles.ts
@@ -13,6 +13,12 @@ export const styles = tv(
         },
         false: {},
       },
+      look: {
+        unstyled: {
+          button: 'p-0 text-left',
+          false: {},
+        },
+      },
     },
   },
   { responsiveVariants: ['xsl', 'sm', 'md', 'lg', 'xl'] },


### PR DESCRIPTION
unstyled inline popover with customised look must not have padding and trigger button should have text left aligned to look cool in small screens #1020