### PR TITLE
[close-button-type-change]- close button type should be of type "button"

### DIFF
--- a/.changeset/fast-dolls-provide.md
+++ b/.changeset/fast-dolls-provide.md
@@ -1,0 +1,5 @@
+---
+'@westpac/ui': patch
+---
+
+When Alert are put in Form and click on close button, It triggers onsubmit action due default type of button is submit for most of the browsers

--- a/packages/ui/src/components/alert/alert.component.tsx
+++ b/packages/ui/src/components/alert/alert.component.tsx
@@ -69,7 +69,7 @@ export function Alert({
                 {children}
               </div>
               {dismissible && mode !== 'text' && (
-                <button className={styles.close()} onClick={handleClose} aria-label="Close alert">
+                <button type="button" className={styles.close()} onClick={handleClose} aria-label="Close alert">
                   <CloseIcon size="small" />
                 </button>
               )}


### PR DESCRIPTION
Default type 'submit' causes form to trigger submit action when placed inside FORM tag.
This can happen when FORM tag is in parent for long forms and child components wants to show dismissible alert.