### PR TITLE
fix(#1055) update tailwind config for protoform/site

### DIFF
--- a/apps/protoform/tailwind.config.ts
+++ b/apps/protoform/tailwind.config.ts
@@ -5,6 +5,9 @@ const config = withGEL({
   relative: true,
   content: ['./src/**/*.{js,ts,jsx,tsx,mdx}', './node_modules/@westpac/ui/src/**/*.{js,ts,jsx,tsx,mdx}'],
   safelist: [],
+  future: {
+    hoverOnlyWhenSupported: true,
+  },
 });
 
 export default config;

--- a/apps/site/tailwind.config.ts
+++ b/apps/site/tailwind.config.ts
@@ -119,6 +119,9 @@ const config: Config = withGEL({
       display: 'block',
     },
   },
+  future: {
+    hoverOnlyWhenSupported: true,
+  },
 });
 
 export default config;


### PR DESCRIPTION
- added hoverOnlyWhenSupported to protoform/site configs so buttons don't stay in hover state once pressed on mobile