### PR TITLE
Fixes/1047 autocomplete dropdown

### DIFF
--- a/.changeset/calm-kangaroos-train.md
+++ b/.changeset/calm-kangaroos-train.md
@@ -1,0 +1,5 @@
+---
+'@westpac/ui': patch
+---
+
+style updates for autocomplete

--- a/apps/site/src/content/design-system/components/autocomplete/code/development-examples/content.mdoc
+++ b/apps/site/src/content/design-system/components/autocomplete/code/development-examples/content.mdoc
@@ -150,3 +150,26 @@
   );
 };
 ```
+### Customised Items
+
+```jsx
+<Autocomplete aria-label="Animals">
+  <AutocompleteItem key="BSB">
+    <div className="flex flex-col">
+      <h3 className="typography-body-9 font-medium">Business Name</h3>
+      <p>12 345 678 910</p>
+    </div>
+  </AutocompleteItem>,
+  <AutocompleteItem key="staff">
+    <div className="flex items-center gap-2">
+      <Circle className="size-5 bg-muted text-white">SN</Circle>
+      <div className="flex flex-col ">
+        <h3 className="typography-body-9">Staff Name</h3>
+        <p className="typography-body-10 text-borderDark group-hover:text-white group-[.is-focused]:text-white">
+          Staff role, staff business area
+        </p>
+      </div>
+    </div>
+  </AutocompleteItem>
+</Autocomplete>
+```

--- a/packages/ui/src/components/autocomplete/autocomplete.stories.tsx
+++ b/packages/ui/src/components/autocomplete/autocomplete.stories.tsx
@@ -3,6 +3,7 @@ import { type Meta, StoryFn, type StoryObj } from '@storybook/react';
 import { useRef, useState } from 'react';
 
 import { FIXED_WIDTHS } from '../../constants/input-widths.js';
+import { Circle } from '../circle/circle.component.js';
 
 import { Autocomplete } from './autocomplete.component.js';
 import { AutocompleteItem } from './components/autocomplete-item/autocomplete-item.component.js';
@@ -275,4 +276,32 @@ export const TestPassingRefAndFocus = () => {
       <button onClick={() => autocompleteRef.current?.focus()}>Test focus</button>
     </div>
   );
+};
+
+/**
+ * > Custom item example
+ */
+export const UsingCustomItems: Story = {
+  args: {
+    'aria-label': 'Custom Items',
+    children: [
+      <AutocompleteItem key="BSB">
+        <div className="flex flex-col">
+          <h3 className="typography-body-9 font-medium">Business Name</h3>
+          <p>12 345 678 910</p>
+        </div>
+      </AutocompleteItem>,
+      <AutocompleteItem key="staff">
+        <div className="flex items-center gap-2">
+          <Circle className="size-5 bg-muted text-white">SN</Circle>
+          <div className="flex flex-col ">
+            <h3 className="typography-body-9">Staff Name</h3>
+            <p className="typography-body-10 text-borderDark group-hover:text-white group-[.is-focused]:text-white">
+              Staff role, staff business area
+            </p>
+          </div>
+        </div>
+      </AutocompleteItem>,
+    ],
+  },
 };

--- a/packages/ui/src/components/autocomplete/components/autocomplete-list-box/autocomplete-list-box.component.tsx
+++ b/packages/ui/src/components/autocomplete/components/autocomplete-list-box/autocomplete-list-box.component.tsx
@@ -15,7 +15,7 @@ export function AutocompleteListBox(props: AutocompleteListBoxProps) {
   const { listBoxProps } = useListBox(props, state, listBoxRef);
 
   return (
-    <ul {...listBoxProps} ref={listBoxRef} className="max-h-[400px] w-full overflow-auto outline-none">
+    <ul {...listBoxProps} ref={listBoxRef} className="max-h-[400px] w-full outline-none">
       {[...state.collection].map(item =>
         item.type === 'section' ? (
           <AutocompleteListBoxSection key={item.key} section={item} state={state} />

--- a/packages/ui/src/components/autocomplete/components/autocomplete-list-box/components/autocomplete-list-box-option/autocomplete-list-box-option.styles.ts
+++ b/packages/ui/src/components/autocomplete/components/autocomplete-list-box/components/autocomplete-list-box-option/autocomplete-list-box-option.styles.ts
@@ -2,10 +2,10 @@ import { tv } from 'tailwind-variants';
 
 export const styles = tv(
   {
-    base: 'flex cursor-pointer items-center justify-between border-t border-t-border bg-white p-2 px-3 text-sm text-text transition-colors first:border-t-0 hover:bg-hero hover:text-white focus:bg-hero focus:text-white',
+    base: 'border-t-border text-text hover:bg-hero focus:bg-hero group flex cursor-pointer items-center justify-between border-t bg-white p-2 px-3 text-sm transition-colors first:border-t-0 hover:text-white focus:text-white',
     variants: {
       isFocused: {
-        true: 'bg-hero !text-white',
+        true: 'bg-hero is-focused !text-white',
       },
       isSelected: {
         true: 'font-bold',

--- a/packages/ui/src/components/autocomplete/components/autocomplete-popover/autocomplete-popover.component.tsx
+++ b/packages/ui/src/components/autocomplete/components/autocomplete-popover/autocomplete-popover.component.tsx
@@ -37,7 +37,7 @@ export function AutocompletePopover(props: AutocompletePopoverProps) {
         {...popoverProps}
         style={{ ...popoverProps.style, width: width ? `${width}px` : undefined }}
         ref={popoverRef}
-        className={clsx('z-10 border border-border bg-white shadow-lg', className)}
+        className={clsx('border-border z-10 max-h-[400px] overflow-auto border bg-white shadow-lg', className)}
       >
         {!isNonModal && <DismissButton onDismiss={state.close} />}
         {children}


### PR DESCRIPTION
- updated style for autocomplete listbox so it will stay contained within the screen
- updated style for autocomplete items so hover/focus states of the parent item can be accessed by children in custom items
- added an example to storybook and the docs site for using custom items in the autocomplete