### PR TITLE
Fix/fixed header is scrolled fix

### DIFF
--- a/.changeset/fresh-cats-shake.md
+++ b/.changeset/fresh-cats-shake.md
@@ -1,0 +1,5 @@
+---
+'@westpac/ui': patch
+---
+
+fixed issue where adding custom scroll trigger to fixed header would only trigger the drop shadow style when the custom trigger was scrolled when it should be used as an additional trigger, not a replacement

--- a/packages/ui/src/components/header/header.component.tsx
+++ b/packages/ui/src/components/header/header.component.tsx
@@ -93,7 +93,7 @@ export function Header({
 
   const ButtonIcon = leftIcon === 'arrow' ? ArrowLeftIcon : HamburgerMenuIcon;
 
-  const styles = headerStyles({ logoCenter, fixed, leftIcon, scrolled: isScrolled ?? scrolled });
+  const styles = headerStyles({ logoCenter, fixed, leftIcon, scrolled: isScrolled || scrolled });
 
   return (
     <header className={styles.base({ className })} {...props}>


### PR DESCRIPTION
- fixed issue where adding custom scroll trigger to fixed header would only trigger the drop shadow style when the custom trigger was scrolled when it should be used as an additional trigger, not a replacement