### PR TITLE
fix alert text wrapping in xsl breakpoint

### DIFF
--- a/.changeset/alert-xsl-text-wrapping.md
+++ b/.changeset/alert-xsl-text-wrapping.md
@@ -1,0 +1,11 @@
+---
+'@westpac/ui': patch
+---
+
+Fix Alert text wrapping below the `xsl` breakpoint
+
+The Alert `base` slot only applied `flex` at the `xsl` breakpoint and above, so
+on smaller viewports the icon and body were not laid out as flex items and the
+text wrapped incorrectly. The `flex` layout is now applied at all breakpoints.
+
+No consumer action is required. The fix is applied automatically on upgrade.

--- a/packages/ui/src/components/alert/alert.styles.ts
+++ b/packages/ui/src/components/alert/alert.styles.ts
@@ -2,7 +2,7 @@ import { tv } from 'tailwind-variants';
 
 export const styles = tv({
   slots: {
-    base: 'relative mb-5 typography-body-10 xsl:flex',
+    base: 'relative mb-5 typography-body-10 flex',
     icon: 'float-left flex-none',
     body: 'relative flex-1 xsl:top-[0.125rem] [&_:focus-visible]:focus-outline [&_a]:underline',
     heading: 'mb-1 typography-body-9 font-bold',


### PR DESCRIPTION
**Issue**
Below the xsl breakpoint (576px), the Alert layout only became a flex row at xsl and up (xsl:flex). On smaller screens (eg mobile view), it fell back to positioning the icon with float-left, so body text wrapped around the icon instead of sitting beside it.
<img width="427" height="139" alt="image" src="https://github.com/user-attachments/assets/bda1cefe-a77f-49b8-aa05-482ddaa50eb4" />

**Fix**
Apply flex to the base slot at all breakpoints instead of only xsl:flex, so the icon and body always sit in separate columns.

**Why**
Related issue: [TVD-116870](https://jira.srv.westpac.com.au/browse/TVD-116870). It removes the need for consumers to patch this themselves (e.g. cassini-fixedrateexpiryperiodamendments was adding flex manually to work around it, see screenshot).
<img width="428" height="145" alt="image" src="https://github.com/user-attachments/assets/b2cdc2b1-1454-4052-add3-ca7c9043fe8d" />