### PR TITLE
fix site page links to preserve selected tab

### DIFF
--- a/apps/site/src/app/design-system/[brand]/(client)/[...component]/components/content-tabs/components/intro/components/table-of-contents/table-of-contents.component.tsx
+++ b/apps/site/src/app/design-system/[brand]/(client)/[...component]/components/content-tabs/components/intro/components/table-of-contents/table-of-contents.component.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { List, ListItem } from '@westpac/ui';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useSearchParams } from 'next/navigation';
 import { ReactNode } from 'react';
 
 import { ArrowDownRightIcon } from '@/components/icons';
@@ -46,6 +46,8 @@ export function TableOfContents({ contents = [] }: TableOfContentsProps) {
 
 function NavLink({ href, children }: { children?: ReactNode; href: string }) {
   const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const query = searchParams.toString();
 
   return (
     <Link
@@ -54,7 +56,7 @@ function NavLink({ href, children }: { children?: ReactNode; href: string }) {
         hover:underline
         focus-visible:focus-outline
       `}
-      href={`${pathname}${href}`}
+      href={`${pathname}${query ? `?${query}` : ''}${href}`}
       replace
       scroll
     >

--- a/apps/site/src/app/design-system/[brand]/(client)/[...component]/components/content-tabs/components/intro/components/table-of-contents/table-of-contents.component.tsx
+++ b/apps/site/src/app/design-system/[brand]/(client)/[...component]/components/content-tabs/components/intro/components/table-of-contents/table-of-contents.component.tsx
@@ -48,6 +48,7 @@ function NavLink({ href, children }: { children?: ReactNode; href: string }) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const query = searchParams.toString();
+  const queryString = query ? `?${query}` : '';
 
   return (
     <Link
@@ -56,7 +57,7 @@ function NavLink({ href, children }: { children?: ReactNode; href: string }) {
         hover:underline
         focus-visible:focus-outline
       `}
-      href={`${pathname}${query ? `?${query}` : ''}${href}`}
+      href={`${pathname}${queryString}${href}`}
       replace
       scroll
     >


### PR DESCRIPTION
Fixes a bug in the site that meant the table of contents links would return to the default tab (in this instance, Design), rather than navigating to the relevant content. This change now preserves the tab the user is on.