### PR TITLE
Allow multiple values to be pasted in mobile browser

### DIFF
--- a/packages/ui/src/components/pass-code/pass-code.component.tsx
+++ b/packages/ui/src/components/pass-code/pass-code.component.tsx
@@ -51,26 +51,39 @@ export const PassCode = forwardRef<PassCodeRef, PassCodeProps>(
 
     const handleChange = useCallback(
       (index: number, event: ChangeEvent<HTMLInputElement>) => {
-        const inputValue = event.target.value.slice(-1);
-        if (
-          (type === 'numbers' && /^\d$/.test(inputValue)) ||
-          (type === 'letters' && /^[a-zA-Z]$/.test(inputValue)) ||
-          (type === 'alphanumeric' && /^[a-zA-Z0-9]$/.test(inputValue))
-        ) {
-          const newPasscode = [...passcode.slice(0, index), inputValue, ...passcode.slice(index + 1)];
-          if (onChange) {
-            onChange(newPasscode);
-          } else {
-            setInternalPasscode(newPasscode);
-          }
+        const inputValue = event.target.value;
+        const validData = inputValue
+          .split('')
+          .filter(char => {
+            if (type === 'numbers') return /^\d$/.test(char);
+            if (type === 'letters') return /^[a-zA-Z]$/.test(char);
+            return /^[a-zA-Z0-9]$/.test(char);
+          })
+          .slice(0, length - index);
 
-          // Move to the next input if available
-          if (index < length - 1 && inputValue !== '') {
-            inputRefs.current[index + 1]?.focus();
-          }
-          if (newPasscode.filter(passcode => !passcode).length === 0 && onComplete) {
-            onComplete(newPasscode.join(''));
-          }
+        if (validData.length === 0) {
+          return;
+        }
+
+        const previousSlice = passcode.slice(0, index);
+        const afterSlice = passcode.slice(index);
+        const newPasscode = [...previousSlice, ...[...validData, ...afterSlice.slice(validData.length)]].slice(
+          0,
+          length,
+        );
+
+        if (onChange) {
+          onChange(newPasscode);
+        } else {
+          setInternalPasscode(newPasscode);
+        }
+
+        // Move to the next input if available
+        if (index + validData.length < length) {
+          inputRefs.current[index + validData.length]?.focus();
+        }
+        if (newPasscode.filter(passcode => !passcode).length === 0 && onComplete) {
+          onComplete(newPasscode.join(''));
         }
       },
       [passcode, length, onChange, onComplete, type],
@@ -81,13 +94,13 @@ export const PassCode = forwardRef<PassCodeRef, PassCodeProps>(
         event.preventDefault();
         const pastedData = event.clipboardData.getData('text');
         const validData = pastedData
-          .slice(0, length - index)
           .split('')
           .filter(char => {
             if (type === 'numbers') return /^\d$/.test(char);
             if (type === 'letters') return /^[a-zA-Z]$/.test(char);
             return /^[a-zA-Z0-9]$/.test(char);
-          });
+          })
+          .slice(0, length - index);
         const previousSlice = passcode.slice(0, index);
         const afterSlice = passcode.slice(index);
         const newPasscode = [...previousSlice, ...[...validData, ...afterSlice.slice(validData.length)]].slice(

--- a/packages/ui/src/components/pass-code/pass-code.spec.tsx
+++ b/packages/ui/src/components/pass-code/pass-code.spec.tsx
@@ -42,6 +42,45 @@ describe('PassCode', () => {
     expect(onCompleteMock).toHaveBeenCalledWith('1234');
   });
 
+  it('handles multiple characters from a change event', () => {
+    const onCompleteMock = vi.fn();
+    render(<PassCode length={4} type="numbers" onComplete={onCompleteMock} />);
+
+    fireEvent.change(screen.getByLabelText(PASSCODE_DIGIT_1), { target: { value: '1234' } });
+
+    expect(screen.getByLabelText<HTMLInputElement>(PASSCODE_DIGIT_1).value).toBe('1');
+    expect(screen.getByLabelText<HTMLInputElement>(PASSCODE_DIGIT_2).value).toBe('2');
+    expect(screen.getByLabelText<HTMLInputElement>(PASSCODE_DIGIT_3).value).toBe('3');
+    expect(screen.getByLabelText<HTMLInputElement>(PASSCODE_DIGIT_4).value).toBe('4');
+    expect(onCompleteMock).toHaveBeenCalledOnce();
+    expect(onCompleteMock).toHaveBeenCalledWith('1234');
+  });
+
+  it('moves focus to the next input after multiple characters', () => {
+    render(<PassCode length={4} type="numbers" />);
+
+    fireEvent.change(screen.getByLabelText(PASSCODE_DIGIT_1), { target: { value: '12' } });
+
+    expect(screen.getByLabelText<HTMLInputElement>(PASSCODE_DIGIT_1).value).toBe('1');
+    expect(screen.getByLabelText<HTMLInputElement>(PASSCODE_DIGIT_2).value).toBe('2');
+    expect(document.activeElement).toBe(screen.getByLabelText(PASSCODE_DIGIT_3));
+  });
+
+  it('limits multiple characters to the inputs available after the current index', () => {
+    const onCompleteMock = vi.fn();
+    render(<PassCode length={4} type="numbers" onComplete={onCompleteMock} />);
+
+    fireEvent.change(screen.getByLabelText(PASSCODE_DIGIT_1), { target: { value: '1' } });
+    fireEvent.change(screen.getByLabelText(PASSCODE_DIGIT_2), { target: { value: '2345' } });
+
+    expect(screen.getByLabelText<HTMLInputElement>(PASSCODE_DIGIT_1).value).toBe('1');
+    expect(screen.getByLabelText<HTMLInputElement>(PASSCODE_DIGIT_2).value).toBe('2');
+    expect(screen.getByLabelText<HTMLInputElement>(PASSCODE_DIGIT_3).value).toBe('3');
+    expect(screen.getByLabelText<HTMLInputElement>(PASSCODE_DIGIT_4).value).toBe('4');
+    expect(onCompleteMock).toHaveBeenCalledOnce();
+    expect(onCompleteMock).toHaveBeenCalledWith('1234');
+  });
+
   it('triggers the onPasteComplete correctly', () => {
     const onPasteCompleteMock = vi.fn();
     render(<PassCode length={4} onPasteComplete={onPasteCompleteMock} />);
@@ -54,6 +93,24 @@ describe('PassCode', () => {
     });
 
     // Ensure the onPasteComplete callback is called with the correct passcode
+    expect(onPasteCompleteMock).toHaveBeenCalledWith('1234');
+  });
+
+  it('strips invalid characters before limiting pasted data', () => {
+    const onPasteCompleteMock = vi.fn();
+    render(<PassCode length={4} type="numbers" onPasteComplete={onPasteCompleteMock} />);
+
+    fireEvent.paste(screen.getByLabelText(PASSCODE_DIGIT_1), {
+      clipboardData: {
+        getData: () => '12-34',
+      },
+    });
+
+    expect(screen.getByLabelText<HTMLInputElement>(PASSCODE_DIGIT_1).value).toBe('1');
+    expect(screen.getByLabelText<HTMLInputElement>(PASSCODE_DIGIT_2).value).toBe('2');
+    expect(screen.getByLabelText<HTMLInputElement>(PASSCODE_DIGIT_3).value).toBe('3');
+    expect(screen.getByLabelText<HTMLInputElement>(PASSCODE_DIGIT_4).value).toBe('4');
+    expect(onPasteCompleteMock).toHaveBeenCalledOnce();
     expect(onPasteCompleteMock).toHaveBeenCalledWith('1234');
   });
 


### PR DESCRIPTION
The mobile keyboard paste / auto-fill sends out a change event, rather than a paste event. Updated the pass-code component's handleChange to be able to process multiple characters at a time, rather than only being able to process a single character.